### PR TITLE
Make the specifier of HTTP response code more directive

### DIFF
--- a/app/controllers/stars_controller.rb
+++ b/app/controllers/stars_controller.rb
@@ -1,6 +1,6 @@
 class StarsController < ApplicationController
   rescue_from Octokit::NotFound do
-    render status: 404, file: 'public/404.html', layout: false
+    render status: :not_found, file: 'public/404.html', layout: false
   end
 
   def index


### PR DESCRIPTION
好みの話かもしれませんが、render時のstatusオプションの指定は、数字の直指定より、:not_found等のシンボル指定のほうが、わかりやすいかなと思っています。
