### PR TITLE
Fix SSL Error since Redis 7.0.15

### DIFF
--- a/app/models/daily_mail_scheduler.rb
+++ b/app/models/daily_mail_scheduler.rb
@@ -64,9 +64,17 @@ module DailyMailScheduler
     private
 
     def redis
-      @redis ||= begin
-        RedisClient.config(url: Settings.redis_url).new_client
-      end
+      @redis ||=
+        begin
+          config = RedisClient.config(
+            url: Settings.redis_url,
+            ssl_params: {
+              verify_mode: OpenSSL::SSL::VERIFY_NONE
+            }
+          )
+
+          config.new_client
+        end
     end
 
     def status_for_user(user)


### PR DESCRIPTION
Since the following update, SSL connection has been required.
```
heroku-redis: Update REDIS by heroku-redis
Oct 16 at 5:30 AM · v714 · Roll back to here
```

However, Heroku requires verify mode is none.
- https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby
- https://help.heroku.com/HC0F8CUS/heroku-key-value-store-connection-issues