### PR TITLE
Upgrade Ruby version from 4.0.5 to 4.0.6

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: 4.0.5
+          ruby-version: 4.0.6
       - uses: reviewdog/action-brakeman@5083efd49634e26645a0736681b618ccc3fb7f14 # v2.19.2
         with:
           reporter: github-pr-review # Default is github-pr-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         options: --entrypoint redis-server
 
     container:
-      image: ruby:4.0.5
+      image: ruby:4.0.6
       env:
         BASE_URL: 'http://example.com'
         DATABASE_URL: postgresql://postgres:password@postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:4.0.5
+FROM ruby:4.0.6
 RUN apt-get update -qq && apt-get install -y postgresql-client
 RUN mkdir /app
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '4.0.5'
+ruby '4.0.6'
 
 gem 'rails', '~> 8.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-  ruby 4.0.5
+  ruby 4.0.6
 
 BUNDLED WITH
   4.0.18


### PR DESCRIPTION
## Summary
This pull request upgrades the Ruby runtime version from 4.0.5 to 4.0.6 across all configuration files and deployment manifests.

## Key Changes
- Updated Ruby version in `Gemfile` from 4.0.5 to 4.0.6
- Updated Docker base image in `Dockerfile` from `ruby:4.0.5` to `ruby:4.0.6`
- Updated Ruby version in GitHub Actions workflow (brakeman.yml) from 4.0.5 to 4.0.6
- Updated container image in GitHub Actions workflow (build.yml) from `ruby:4.0.5` to `ruby:4.0.6`

## Notes
This is a patch version upgrade that ensures consistency across development, CI/CD, and production environments.

https://claude.ai/code/session_01FHzSziqxw6cXAvcDXePFba