### PR TITLE
Fix N+1 query in StarEvent.starred_ranking

### DIFF
--- a/app/models/star_event.rb
+++ b/app/models/star_event.rb
@@ -7,18 +7,19 @@ class StarEvent < ApplicationRecord
   scope :owner, ->(login) { where(repo_owner: login) }
 
   class << self
+    # Group events by repository and order them by popularity.
+    #
+    # Returns an array of [repo_name, events, repository] tuples, where +events+
+    # is ordered newest first.  Events whose repository is not stored yet are
+    # excluded by the join, so every tuple has a repository.
+    #
+    # (actor_login, repo_name) is unique at the database level, so an actor
+    # never appears twice within a group.
     def starred_ranking
-      star_events = all.newly.to_a
-      star_events = star_events.uniq { |e| [e.repo_name, e.actor_login].hash }
-
-      grouped_events = star_events.group_by(&:repo_name)
-      grouped_events = grouped_events.sort_by { |_, events| [-events.count, -events.first.starred_at.to_i] }
-      grouped_events = grouped_events.filter_map do |repo_name, events|
-        repo = events.first.repository
-        [repo_name, events, repo] if repo
-      end
-
-      grouped_events
+      joins(:repository).includes(:repository).newly.to_a
+        .group_by(&:repo_name)
+        .sort_by {|_, events| [-events.count, -events.first.starred_at.to_i] }
+        .map {|repo_name, events| [repo_name, events, events.first.repository] }
     end
 
     def each_with_repo

--- a/spec/models/star_event_spec.rb
+++ b/spec/models/star_event_spec.rb
@@ -1,4 +1,52 @@
 describe StarEvent do
+  describe '.starred_ranking' do
+    subject(:ranking) { StarEvent.starred_ranking }
+
+    before do
+      stub_repository! 'popular/repo'
+      stub_repository! 'newer/repo'
+
+      stub_star_event! actor: {login: 'alice'}, repo: {name: 'popular/repo'}, starred_at: 3.hours.ago
+      stub_star_event! actor: {login: 'bob'},   repo: {name: 'popular/repo'}, starred_at: 2.hours.ago
+      stub_star_event! actor: {login: 'carol'}, repo: {name: 'newer/repo'},   starred_at: 1.hour.ago
+      # No Repository record is stored for this one.
+      stub_star_event! actor: {login: 'dave'},  repo: {name: 'unknown/repo'}, starred_at: 30.minutes.ago
+    end
+
+    it 'orders repositories by star count, then by recency' do
+      expect(ranking.map(&:first)).to eq(['popular/repo', 'newer/repo'])
+    end
+
+    it 'excludes events whose repository is not stored yet' do
+      expect(ranking.map(&:first)).not_to include('unknown/repo')
+    end
+
+    it 'orders the events of each repository newest first' do
+      _repo_name, events, _repo = ranking.first
+
+      expect(events.map(&:actor_login)).to eq(%w(bob alice))
+    end
+
+    it 'returns the repository of each group' do
+      _repo_name, _events, repo = ranking.first
+
+      expect(repo).to eq(Repository.find_by(name: 'popular/repo'))
+    end
+
+    it 'does not query the repositories table once per group' do
+      queries = 0
+      counter = ->(_name, _start, _finish, _id, payload) {
+        queries += 1 if payload[:sql].include?('FROM "repositories"') && !payload[:cached]
+      }
+
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+        StarEvent.starred_ranking
+      end
+
+      expect(queries).to be <= 1
+    end
+  end
+
   describe '.fetch_and_upsert' do
     subject(:fetch) { StarEvent.fetch_and_upsert(token: token, logins: logins, since: since) }
 


### PR DESCRIPTION
`starred_ranking` called `events.first.repository` once per repository group without eager loading, so building the ranking issued one query per group. It is called on every dashboard render (twice), on the hot repositories page, on the Atom feed and in the daily mail, so the cost is paid on every one of those.

## Changes

- Preload the repositories together with the events.
- Drop events whose repository is not stored yet with an `INNER JOIN` instead of `filter_map` in Ruby, so they are never loaded. Grouping is by `repo_name` and the repository is looked up by the same column, so every event in a group shares its repository's presence — the result is unchanged.
- Drop the in-memory `uniq`. `(actor_login, repo_name)` is unique at the database level (`index_star_events_on_actor_login_and_repo_name`), so it could never remove anything. It also used `Array#hash` as the uniq key, which needlessly relied on hash equality instead of comparing the values.
- Collapse the four intermediate assignments into a single chain.

```ruby
def starred_ranking
  joins(:repository).includes(:repository).newly.to_a
    .group_by(&:repo_name)
    .sort_by {|_, events| [-events.count, -events.first.starred_at.to_i] }
    .map {|repo_name, events| [repo_name, events, events.first.repository] }
end
```

## Tests

`spec/models/star_event_spec.rb` had no coverage for this method. Added specs for the ordering (count, then recency), the ordering within a group, the exclusion of events without a stored repository, and a query counter asserting the repositories table is not queried once per group.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_