### PR TITLE
Return 401 instead of 500 for a feed request without a token

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -19,9 +19,9 @@ class ActivitiesController < ApplicationController
   private
 
   def login_from_feed_token
-    head :unauthorized if params[:token].blank?
+    return head :unauthorized if params[:token].blank?
 
-    @user = User.where(username: params[:username], feed_token: params[:token]).first
+    @user = User.find_by(username: params[:username], feed_token: params[:token])
 
     head :unauthorized unless @user
   end

--- a/spec/features/activity_spec.rb
+++ b/spec/features/activity_spec.rb
@@ -27,4 +27,16 @@ feature 'Activity' do
     expect(page.body).to match(%r{\A<\?xml version="1\.0" encoding="UTF-8"\?>})
     expect(page.body).to match('<title>DIO/the-world</title>')
   end
+
+  scenario 'News Feed without a token' do
+    visit feed_path(username: user.username, format: 'atom')
+
+    expect(page.status_code).to eq(401)
+  end
+
+  scenario 'News Feed with an invalid token' do
+    visit feed_path(username: user.username, format: 'atom', token: 'INVALID_TOKEN')
+
+    expect(page.status_code).to eq(401)
+  end
 end


### PR DESCRIPTION
`ActivitiesController#login_from_feed_token` responded with 401 for a blank token but did not return:

```ruby
head :unauthorized if params[:token].blank?

@user = User.where(username: params[:username], feed_token: params[:token]).first

head :unauthorized unless @user
```

Execution fell through to the lookup, which ran with `feed_token: nil` and found nobody, so the filter responded a second time and Rails raised `AbstractController::DoubleRenderError`. A feed request without a token therefore returned 500 rather than 401.

## Changes

- Return after the first response.
- While in the method, replace `where(...).first` with `find_by`.

## Tests

Added feature specs for a feed request with no token and with an invalid token, both expecting 401.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_