### PR TITLE
Give `render file:` an absolute path for the 404 page

### DIFF
--- a/app/controllers/stars_controller.rb
+++ b/app/controllers/stars_controller.rb
@@ -1,6 +1,8 @@
 class StarsController < ApplicationController
   rescue_from Octokit::NotFound do
-    render status: :not_found, file: 'public/404.html', layout: false
+    # `render file:` resolves its argument with File.exist?, so a relative path
+    # only works while the working directory happens to be the app root.
+    render status: :not_found, file: Rails.public_path.join('404.html').to_s, layout: false
   end
 
   def index

--- a/spec/features/stars_page_spec.rb
+++ b/spec/features/stars_page_spec.rb
@@ -20,4 +20,14 @@ feature 'Stars page' do
     expect(page).to have_list('[25]')
     expect(page).to have_link('#GitHub')
   end
+
+  scenario 'Show 404 page for an unknown user' do
+    github_client = instance_double(Octokit::Client)
+    allow(github_client).to receive(:user).and_raise(Octokit::NotFound)
+    allow(Settings).to receive(:github_client).and_return(github_client)
+
+    visit stars_path(username: 'unknown-user')
+
+    expect(page.status_code).to eq(404)
+  end
 end


### PR DESCRIPTION
`StarsController` rescues `Octokit::NotFound` with `render file: 'public/404.html'`.

Rails locates the file with `File.exist?(options[:file])` and raises `ArgumentError` ("`render file:` should be given the absolute path to a file") when it does not exist. `File.exist?` resolves a relative path against the process working directory, not the app root, so this happens to work today and breaks as soon as the app is started from anywhere else — at which point the 404 handler raises instead of rendering the 404 page.

## Changes

Pass `Rails.public_path.join('404.html').to_s`.

## Tests

This rescue path had no coverage. Added a feature spec that stubs `Settings.github_client` to raise `Octokit::NotFound` for an unknown username and expects a 404.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_