### PR TITLE
Actually memoize Settings.github_client

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -17,16 +17,14 @@ module Settings
     end
 
     def github_client
-      @github_client =
-        begin
-          if ENV['GITHUB_LOGIN'] && ENV['GITHUB_TOKEN']
-            Octokit::Client.new(
-              login: ENV['GITHUB_LOGIN'],
-              access_token: ENV['GITHUB_TOKEN'],
-            )
-          else
-            Octokit::Client.new
-          end
+      @github_client ||=
+        if ENV['GITHUB_LOGIN'] && ENV['GITHUB_TOKEN']
+          Octokit::Client.new(
+            login: ENV['GITHUB_LOGIN'],
+            access_token: ENV['GITHUB_TOKEN'],
+          )
+        else
+          Octokit::Client.new
         end
     end
 


### PR DESCRIPTION
`Settings.github_client` assigns with `=` rather than `||=`, so a new `Octokit::Client` is built on every call and the memoization never takes effect.

```ruby
@github_client =
  begin
    ...
  end
```

## Changes

- `@github_client ||=`.
- Drop the `begin`/`end`, which is redundant now that the assignment takes the `if` expression directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_