### PR TITLE
Move the duplicated star event queries into User

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -4,11 +4,11 @@ class ActivitiesController < ApplicationController
 
   def starring
     @user = current_user
-    @star_events = @user.star_events_by_followings_with_me.latest(1.day.ago)
+    @star_events = @user.daily_star_events_by_followings
   end
 
   def feed
-    @star_events = @user.star_events_by_followings_with_me.latest(1.day.ago)
+    @star_events = @user.daily_star_events_by_followings
     @latest_event = @star_events.newly.first
 
     respond_to do |format|

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,7 @@ class DashboardController < ApplicationController
   before_action :require_login, :assign_current_user
 
   def show
-    @star_events = StarEvent.by(@user.username).latest(7.days.ago).newly
-    @starred_events = StarEvent.owner(@user.username).latest(7.days.ago).newly
+    @star_events = @user.recent_star_events
+    @starred_events = @user.recent_star_events_on_my_repositories
   end
 end

--- a/app/controllers/stars_controller.rb
+++ b/app/controllers/stars_controller.rb
@@ -5,6 +5,6 @@ class StarsController < ApplicationController
 
   def index
     @user = User.find_or_fetch_by_username(params[:username])
-    @star_events = StarEvent.by(@user.username).latest(7.days.ago).newly
+    @star_events = @user.recent_star_events
   end
 end

--- a/app/mailers/my_hot_repository.rb
+++ b/app/mailers/my_hot_repository.rb
@@ -6,7 +6,7 @@ class MyHotRepository < ActionMailer::Base
 
   def notify(user)
     @user = user
-    @star_events = @user.star_events_by_followings_with_me.latest(1.day.ago)
+    @star_events = @user.daily_star_events_by_followings
 
     mail to: user.email, subject: "Starred repositories by #{@user.username}'s followings"
   end

--- a/app/models/daily_mail_scheduler.rb
+++ b/app/models/daily_mail_scheduler.rb
@@ -27,7 +27,7 @@ module DailyMailScheduler
           label = '%s(%s)' % [user.username, user.email]
 
           begin
-            if user_has_starred?(user, 1.day.ago)
+            if user_has_starred?(user)
               MyHotRepository.notify(user).deliver_now
 
               self.logger.info "Send hot repositories mail to \033[36m%s\033[39m." % [label]
@@ -93,8 +93,8 @@ module DailyMailScheduler
       redis.call('HMSET', TABLE_NAME, user.id, Status::FAILED)
     end
 
-    def user_has_starred?(user, term)
-      user.star_events_by_followings_with_me.latest(term).present?
+    def user_has_starred?(user)
+      user.daily_star_events_by_followings.present?
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   MAX_FOLLOWER_PAGE_COUNT = 50
 
+  # How far back the "daily" and "recent" listings look.
+  DAILY_TERM  = 1.day
+  RECENT_TERM = 7.days
+
   scope :email_sendables, -> { where(subscribe: true, activation_state: 'active') }
   scope :newly, -> { order(created_at: :desc) }
   scope :randomly, -> { order(Arel.sql('RANDOM()')) }
@@ -58,6 +62,21 @@ class User < ApplicationRecord
 
   def star_events_by_followings_with_me
     StarEvent.by(followings + [username])
+  end
+
+  # Repositories starred by the people this user follows (and by the user).
+  def daily_star_events_by_followings
+    star_events_by_followings_with_me.latest(DAILY_TERM.ago)
+  end
+
+  # Repositories this user starred recently.
+  def recent_star_events
+    StarEvent.by(username).latest(RECENT_TERM.ago).newly
+  end
+
+  # This user's own repositories that were starred recently by someone.
+  def recent_star_events_on_my_repositories
+    StarEvent.owner(username).latest(RECENT_TERM.ago).newly
   end
 
   def followings


### PR DESCRIPTION
The same two queries were written out at five call sites, with the lookback windows repeated as literals at each one:

- `@user.star_events_by_followings_with_me.latest(1.day.ago)` — `ActivitiesController#starring`, `#feed`, `MyHotRepository#notify`
- `StarEvent.by(username).latest(7.days.ago).newly` — `DashboardController#show`, `StarsController#index`

plus `DailyMailScheduler` passing `1.day.ago` in as an argument.

## Changes

Name the two windows and give `User` the query methods the callers actually want:

```ruby
DAILY_TERM  = 1.day
RECENT_TERM = 7.days

def daily_star_events_by_followings
def recent_star_events
def recent_star_events_on_my_repositories
```

`DailyMailScheduler#user_has_starred?` no longer needs a `term` argument.

No behaviour change — the queries are the same, they are just defined in one place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_