### PR TITLE
Remove the User / Repository::Owner branching from the avatar helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,25 +22,14 @@ module ApplicationHelper
     link_to('[%d]' % repo.stargazers_count, github_url("#{repo.full_name}/stargazers"))
   end
 
-  def image_link_to_github_url(user, size = '30x30')
-    username = user.is_a?(User) ? user.username : user.login
-
-    link_to avatar_image_tag(user, size), github_url(username)
+  # +account+ is anything that responds to #login and #avatar_url:
+  # a User, a Repository::Owner (Repository#owner, StarEvent#actor), ...
+  def image_link_to_github_url(account, size = '30x30')
+    link_to avatar_image_tag(account, size), github_url(account.login)
   end
 
-  def avatar_image_tag(user, size)
-    username, avatar_url = if user.is_a?(User)
-      [user.username, user.avatar_url]
-    else
-      [user.login, user.avatar_url]
-    end
-
-    image_tag(avatar_url, title: username, alt: username, size: size)
-  end
-
-  def image_link_to_github_url_from_event(event)
-    owner = Repository::Owner.new(login: event.actor_login, avatar_url: event.actor_avatar_url)
-    image_link_to_github_url(owner)
+  def avatar_image_tag(account, size)
+    image_tag(account.avatar_url, title: account.login, alt: account.login, size: size)
   end
 
   def html_title_about_user(user)

--- a/app/models/star_event.rb
+++ b/app/models/star_event.rb
@@ -28,6 +28,13 @@ class StarEvent < ApplicationRecord
     end
   end
 
+  # The GitHub account that starred the repository.
+  # Duck-types with Repository#owner and User so that view helpers can take
+  # either of them.
+  def actor
+    Repository::Owner.new(login: actor_login, avatar_url: actor_avatar_url)
+  end
+
   concerning :Fetchable do
     FETCH_CONCURRENCY = ENV.fetch('FETCH_CONCURRENCY', 5).to_i
     # Keep batches small enough to stay within GitHub's per-query resource

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,14 @@ class User < ApplicationRecord
     end
   end
 
+  # GitHub's own naming for a username, so that a User duck-types with
+  # Repository::Owner wherever a GitHub account is rendered.
+  # (Not `alias_method`: `username` is a lazily generated attribute method and
+  # is not defined yet while this class body is evaluated.)
+  def login
+    username
+  end
+
   def access_token
     @access_token ||= authentications.find_by(provider: :github)&.token
   end

--- a/app/views/activities/starring.html.haml
+++ b/app/views/activities/starring.html.haml
@@ -23,7 +23,7 @@ Starred repositories by #{@user.username}'s followings
           = link_to_language repo
         %span.stargazers
           - events.each do |event|
-            = image_link_to_github_url_from_event(event)
+            = image_link_to_github_url event.actor
       %div
         %span.description
           = repo.description

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -46,7 +46,7 @@
         = link_to_language repo
       %span.stargazers
         - events.each do |event|
-          = image_link_to_github_url_from_event(event)
+          = image_link_to_github_url event.actor
           %span.starred_at
             = time_ago_in_words event.starred_at
       %div

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,6 +5,32 @@ describe ApplicationHelper do
     end
   end
 
+  describe '#image_link_to_github_url' do
+    context 'with a User' do
+      let(:account) { create(:user) }
+
+      it 'links to the GitHub account page' do
+        expect(image_link_to_github_url(account)).to include('https://github.com/USER')
+      end
+
+      it 'renders the avatar of the account' do
+        expect(image_link_to_github_url(account)).to include(account.avatar_url)
+      end
+    end
+
+    context 'with a Repository::Owner' do
+      let(:account) { Repository::Owner.new(login: 'DIO', avatar_url: 'http://example.com/dio.png') }
+
+      it 'links to the GitHub account page' do
+        expect(image_link_to_github_url(account)).to include('https://github.com/DIO')
+      end
+
+      it 'renders the avatar of the account' do
+        expect(image_link_to_github_url(account)).to include('http://example.com/dio.png')
+      end
+    end
+  end
+
   describe '#html_title_about_user' do
     context 'when user has username and name' do
       let(:user) { create(:user) }

--- a/spec/models/star_event_spec.rb
+++ b/spec/models/star_event_spec.rb
@@ -254,4 +254,16 @@ describe StarEvent do
       end
     end
   end
+
+  describe '#actor' do
+    subject(:actor) do
+      StarEvent.new(
+        actor_login: 'DIO',
+        actor_avatar_url: 'http://example.com/dio.png'
+      ).actor
+    end
+
+    its(:login) { is_expected.to eq('DIO') }
+    its(:avatar_url) { is_expected.to eq('http://example.com/dio.png') }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,12 @@ describe User do
     end
   end
 
+  describe '#login' do
+    subject { build(:user, username: 'alice') }
+
+    its(:login) { is_expected.to eq('alice') }
+  end
+
   describe '#feed_token' do
     subject do
       create(:user)


### PR DESCRIPTION
`ApplicationHelper` had three helpers to render one avatar link, all because `User` calls the GitHub handle `username` while `Repository::Owner` calls it `login`:

```ruby
def image_link_to_github_url(user, size = '30x30')
  username = user.is_a?(User) ? user.username : user.login
  ...
end

def avatar_image_tag(user, size)
  username, avatar_url = if user.is_a?(User)
  ...
end

def image_link_to_github_url_from_event(event)
  owner = Repository::Owner.new(login: event.actor_login, avatar_url: event.actor_avatar_url)
  image_link_to_github_url(owner)
end
```

The third existed only to build a `Repository::Owner` out of a `StarEvent` — model construction sitting in the view layer.

## Changes

- `User#login`, returning `username`. (A plain method rather than `alias_method`: `username` is a lazily generated attribute method and is not defined yet while the class body is evaluated.)
- `StarEvent#actor`, returning the `Repository::Owner` for the actor.
- Both helpers now just take anything responding to `#login` and `#avatar_url`, and `image_link_to_github_url_from_event` is gone. Views call `image_link_to_github_url event.actor`.

## Tests

Added specs for `#image_link_to_github_url` with each of the two account types, plus `User#login` and `StarEvent#actor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_