### PR TITLE
Replace the dynamic finders with find_by

### DIFF
--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -17,7 +17,7 @@ module Authenticatable
   end
 
   def current_user
-    @current_user ||= User.find_by_id(session[:user_id])
+    @current_user ||= User.find_by(id: session[:user_id])
   end
 
   def logged_in?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,7 +46,7 @@ class SessionsController < ApplicationController
   end
 
   def activate
-    @user = User.find_by_activation_token(params[:activation_token])
+    @user = User.find_by(activation_token: params[:activation_token])
 
     if @user
       @user.activate!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
 
   class << self
     def find_or_fetch_by_username(username)
-      self.find_by_username(username) || User.new {|user|
+      find_by(username: username) || User.new {|user|
         github_user = Settings.github_client.user(username)
         user.username = github_user.login
         user.avatar_url = github_user.avatar_url


### PR DESCRIPTION
Three call sites still used the `find_by_*` dynamic finders, which are resolved through `method_missing`:

- `User.find_by_username` — `User.find_or_fetch_by_username`
- `User.find_by_activation_token` — `SessionsController#activate`
- `User.find_by_id` — `Authenticatable#current_user`

`find_by` states the column explicitly and is the current idiom. No behaviour change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_