### PR TITLE
Extract the per-user delivery out of send_mail_to_scheduled_users

### DIFF
--- a/app/models/daily_mail_scheduler.rb
+++ b/app/models/daily_mail_scheduler.rb
@@ -2,10 +2,13 @@ module DailyMailScheduler
   TABLE_NAME = 'users_to_be_sent_email'
 
   module Status
-    SCHEDULED   = 'scheduled'
-    FAILED      = 'failed'
-    PROCESSIONG = 'processing'
+    SCHEDULED  = 'scheduled'
+    FAILED     = 'failed'
+    PROCESSING = 'processing'
   end
+
+  # A user in either of these states still has today's mail coming.
+  PENDING_STATUSES = [Status::SCHEDULED, Status::FAILED].freeze
 
   class << self
     attr_accessor :logger
@@ -20,34 +23,10 @@ module DailyMailScheduler
       # TODO Use thread
       scheduled_users.each do |user|
         # TODO Use transaction
-        case status_for_user(user)
-        when Status::SCHEDULED, Status::FAILED
-          start_processing user
+        next unless PENDING_STATUSES.include?(status_for_user(user))
 
-          label = '%s(%s)' % [user.username, user.email]
-
-          begin
-            if user_has_starred?(user)
-              MyHotRepository.notify(user).deliver_now
-
-              self.logger.info "Send hot repositories mail to \033[36m%s\033[39m." % [label]
-            else
-              self.logger.info "Skip sending mail to \033[33m%s\033[39m. Because star events to him are empty." % [label]
-            end
-
-            finish_sending_mail user
-          rescue Octokit::Unauthorized
-            finish_sending_mail user
-
-            self.logger.info "Skip sending mail to \033[31m%s\033[39m. Because of unauthorized Token." % [label]
-          rescue => e
-            schedule_as_retry user
-
-            self.logger.error ["#{e.class} #{e.message}:", *e.backtrace.map {|m| '  '+m }].join("\n")
-          end
-        else
-          # noop
-        end
+        start_processing user
+        deliver_hot_repositories_to user
       end
     end
 
@@ -62,6 +41,35 @@ module DailyMailScheduler
     end
 
     private
+
+    # Deliver today's mail to one user and take them off the schedule.
+    #
+    # The user goes back on the schedule only when the failure looks
+    # retriable. An expired token never becomes valid on a retry, so that case
+    # is dropped with a log line instead.
+    def deliver_hot_repositories_to(user)
+      if user_has_starred?(user)
+        MyHotRepository.notify(user).deliver_now
+
+        logger.info "Send hot repositories mail to \033[36m%s\033[39m." % [label_for(user)]
+      else
+        logger.info "Skip sending mail to \033[33m%s\033[39m. Because star events to him are empty." % [label_for(user)]
+      end
+
+      finish_sending_mail user
+    rescue Octokit::Unauthorized
+      finish_sending_mail user
+
+      logger.info "Skip sending mail to \033[31m%s\033[39m. Because of unauthorized Token." % [label_for(user)]
+    rescue => e
+      schedule_as_retry user
+
+      logger.error ["#{e.class} #{e.message}:", *e.backtrace.map {|m| '  '+m }].join("\n")
+    end
+
+    def label_for(user)
+      '%s(%s)' % [user.username, user.email]
+    end
 
     def redis
       @redis ||=
@@ -82,7 +90,7 @@ module DailyMailScheduler
     end
 
     def start_processing(user)
-      redis.call('HMSET', TABLE_NAME, user.id, Status::PROCESSIONG)
+      redis.call('HMSET', TABLE_NAME, user.id, Status::PROCESSING)
     end
 
     def finish_sending_mail(user)
@@ -99,5 +107,4 @@ module DailyMailScheduler
   end
 
   self.logger = Rails.logger
-
 end

--- a/spec/models/daily_mail_scheduler_spec.rb
+++ b/spec/models/daily_mail_scheduler_spec.rb
@@ -91,6 +91,34 @@ describe DailyMailScheduler do
       end
     end
 
+    context 'When the GitHub token is unauthorized' do
+      before do
+        user.activate!
+
+        allow(subject).to receive(:user_has_starred?).and_raise(Octokit::Unauthorized)
+
+        subject.schedule [user]
+
+        subject.send_mail_to_scheduled_users
+      end
+
+      it 'should skip mail sending' do
+        mail = ActionMailer::Base.deliveries.first
+        expect(mail).to be_nil
+      end
+
+      it 'should clear schedule' do
+        expect(subject.scheduled_users).to be_empty
+      end
+
+      it 'should puts log' do
+        log = io.string.split("\n").first
+
+        expect(log).to match('Because of unauthorized Token')
+        expect(log).to match('USER')
+      end
+    end
+
     context 'When error occurred' do
       let(:error) { StandardError }
 


### PR DESCRIPTION
`send_mail_to_scheduled_users` held the Redis state machine, the delivery, the log formatting and the error handling in one method, nested four levels deep at its innermost point (`each` → `case` → `begin` → `if`).

## Changes

- Split the per-user work into `deliver_hot_repositories_to`, so the loop reads as "for every user still pending, mark them processing and deliver", and the delivery reads as one linear body with its two rescues.
- Replace the `case`/`when` and its `# noop` else with a guard clause over a new `PENDING_STATUSES` constant.
- Pull the log label, built once and used in three messages, into `label_for`.
- `self.logger` inside these methods is just `logger`.

```ruby
def send_mail_to_scheduled_users
  # TODO Use thread
  scheduled_users.each do |user|
    # TODO Use transaction
    next unless PENDING_STATUSES.include?(status_for_user(user))

    start_processing user
    deliver_hot_repositories_to user
  end
end
```

`start_processing` stays in the loop rather than moving into the new method, so it remains outside the rescues exactly as it was.

## Typo

`Status::PROCESSIONG` → `Status::PROCESSING`. Only the constant name changes — the value written to Redis was already `'processing'`, so nothing in the stored state changes.

## Tests

No change to the log messages, or to when a user is taken off / put back on the schedule. The existing specs cover the success, no-stars and generic-error paths; added the missing one for `Octokit::Unauthorized`, which is the branch that drops a user from the schedule without retrying.

The two `# TODO` comments are left as they are — neither is addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_