### PR TITLE
Extract the repository list markup into partials

### DIFF
--- a/app/views/activities/starring.html.haml
+++ b/app/views/activities/starring.html.haml
@@ -12,15 +12,11 @@ Starred repositories by #{@user.username}'s followings
   = link_to '[News Feed]', private_feed, target: '_blank', rel: 'noopener noreferrer'
 
 %ul
-  - @star_events.starred_ranking.each do |repo_name, events, repo|
+  - @star_events.starred_ranking.each do |_repo_name, events, repo|
     %li.repo
       %div
         = image_link_to_github_url repo.owner
-        %span.repo_name
-          = link_to_repo repo_name
-        = link_to_stargazers(repo)
-        %span.language
-          = link_to_language repo
+        = render 'shared/repository_summary', repo: repo
         %span.stargazers
           - events.each do |event|
             = image_link_to_github_url event.actor

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -19,31 +19,16 @@
 (Within 7 days from now)
 %ul.starred_repos_by_user
   - @star_events.each_with_repo do |star_event, repo|
-    %li
-      = image_link_to_github_url repo.owner
-      %span.repo_name
-        = link_to_repo repo.full_name
-      = link_to_stargazers(repo)
-      %span.language
-        = link_to_language repo
-      %span.starred_at
-        = time_ago_in_words star_event.starred_at
-      %div
-        %span.description
-          = repo.description
+    = render 'shared/starred_repository', star_event: star_event, repo: repo
 - if @star_events.empty?
   Not starred.
 
 %h2 Your repositories recently starred by someone:
 (Within 7 days from now)
 %ul.starred_repos_by_someone
-  - @starred_events.starred_ranking.each do |repo_name, events, repo|
+  - @starred_events.starred_ranking.each do |_repo_name, events, repo|
     %li
-      %span.repo_name
-        = link_to_repo repo_name
-      = link_to_stargazers(repo)
-      %span.language
-        = link_to_language repo
+      = render 'shared/repository_summary', repo: repo
       %span.stargazers
         - events.each do |event|
           = image_link_to_github_url event.actor

--- a/app/views/shared/_repository_summary.html.haml
+++ b/app/views/shared/_repository_summary.html.haml
@@ -1,0 +1,6 @@
+-# The repository's name, star count and language, as shown in every listing.
+%span.repo_name
+  = link_to_repo repo.full_name
+= link_to_stargazers(repo)
+%span.language
+  = link_to_language repo

--- a/app/views/shared/_starred_repository.html.haml
+++ b/app/views/shared/_starred_repository.html.haml
@@ -1,0 +1,9 @@
+-# One repository in a "starred recently" listing, with when it was starred.
+%li
+  = image_link_to_github_url repo.owner
+  = render 'shared/repository_summary', repo: repo
+  %span.starred_at
+    = time_ago_in_words star_event.starred_at
+  %div
+    %span.description
+      = repo.description

--- a/app/views/stars/index.html.haml
+++ b/app/views/stars/index.html.haml
@@ -9,18 +9,7 @@
 (Within 7 days from now)
 %ul
   - @star_events.each_with_repo do |star_event, repo|
-    %li
-      = image_link_to_github_url repo.owner
-      %span.repo_name
-        = link_to_repo repo.full_name
-      = link_to_stargazers(repo)
-      %span.language
-        = link_to_language repo
-      %span.starred_at
-        = time_ago_in_words star_event.starred_at
-      %div
-        %span.description
-          = repo.description
+    = render 'shared/starred_repository', star_event: star_event, repo: repo
 
 - if @star_events.empty?
   Not starred.

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -20,9 +20,9 @@ feature 'Dashboard' do
     expect(page).to have_caption('starseeker user')
     expect(page).to have_content('user@starseeker.so')
     expect(page).to have_sub_title('Repositories you starred recently:')
-    expect(page).to have_css('.starred_repos_by_user li', text: 'github/octocat')
+    expect(page).to have_css('.starred_repos_by_user li', text: 'github/octocat [25]')
     expect(page).to have_sub_title('Your repositories recently starred by someone:')
-    expect(page).to have_css('.starred_repos_by_someone li', text: 'USER/try_git')
+    expect(page).to have_css('.starred_repos_by_someone li', text: 'USER/try_git [1]')
     expect(page).to have_sub_title('Menu')
   end
 


### PR DESCRIPTION
The same repository row was written out four times across three templates: the dashboard's two lists, the stars page and the hot repositories page.

## Changes

- **`shared/_repository_summary`** — the name, star count and language. All four listings render this identically.
- **`shared/_starred_repository`** — the whole `<li>` of a "starred recently" listing. The dashboard's first list and the stars page had byte-identical markup for it (`diff` reports no difference), so both now render the partial.

## What is deliberately not merged

The two *ranked* listings keep their own wrappers. They differ in three ways:

| | hot repositories | dashboard "starred by someone" |
|---|---|---|
| owner avatar | shown | omitted — the owner is the user reading the page |
| wrapper | `%li.repo` + inner `%div` | plain `%li` |
| per-actor timestamp | no | yes |

Folding them together would need three flags to say which half to render, which is worse than the duplication. They stay apart and share only `_repository_summary`.

## One value changes source

The partial reads `repo.full_name` where the ranked listings passed the `repo_name` block argument. `starred_ranking` joins the repository on that same column, so the two are always the same string. The block argument is now unused and renamed to `_repo_name`.

## Tests

All four call sites already have feature coverage that asserts the name and the star count as adjacent text, which is what would break if the partial boundary changed the whitespace between those elements — `activity_spec` (`'DIO/the-world [21]'`), `stars_page_spec` (`'github/octocat'`, `'[25]'`) and `my_hot_repository_spec`, which also covers resolving `shared/…` from the mailer's view context.

The dashboard spec asserted only the name, so its two `have_css` matchers now include the star count as well.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp81ha49Y4ujjGvUn6Dbbo)_