### PR TITLE
Update gems and pin json below 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby '4.0.6'
 
 gem 'rails', '~> 8.1.0'
+gem 'json', '< 3' # TODO: Remove once Rails includes https://github.com/rails/rails/pull/58601
 
 gem 'haml'
 gem 'octokit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -125,7 +125,8 @@ GEM
       net-http (~> 0.5)
     globalid (1.4.0)
       activesupport (>= 6.1)
-    haml (7.2.2)
+    haml (7.5.1)
+      prism (>= 1.1.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -133,7 +134,7 @@ GEM
       logger
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -178,7 +179,7 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.1)
       net-protocol
@@ -231,7 +232,7 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -274,7 +275,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rake (13.4.2)
-    rbs (4.1.2)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -286,7 +287,7 @@ GEM
     redis-client (0.30.1)
       connection_pool
     regexp_parser (2.12.0)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     rexml (3.4.4)
     roadie (5.3.1)
@@ -322,10 +323,10 @@ GEM
     snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
       version_gem (~> 1.1, >= 1.1.14)
-    ssrf_filter (1.5.0)
-    temple (0.10.4)
+    ssrf_filter (1.6.0)
+    temple (0.10.7)
     thor (1.5.0)
-    tilt (2.8.0)
+    tilt (2.9.0)
     timeout (0.6.1)
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -358,6 +359,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   haml
+  json (< 3)
   letter_opener_web
   octokit
   omniauth


### PR DESCRIPTION
## Summary

`bundle update --all` の結果と、それに伴う非互換への対応です。

### 更新された gem

| gem | before | after |
| --- | --- | --- |
| haml | 7.2.2 | 7.5.1 |
| brakeman | 8.0.5 | 8.0.6 |
| rack | 3.2.6 | 3.2.7 |
| tilt | 2.8.0 | 2.9.0 |
| temple | 0.10.4 | 0.10.7 |
| ssrf_filter | 1.5.0 | 1.6.0 |
| rbs | 4.1.2 | 4.2.0 |
| reline | 0.6.3 | 0.7.0 |
| io-console | 0.8.2 | 0.9.2 |
| net-protocol | 0.2.2 | 0.3.0 |

### 非互換: json 3.0 と Rails 8.1.3.1

制約なしで更新すると json が 2.21.2 → 3.0.2 に上がりますが、json 3.0 では `JSON.parse` の位置引数 `opts` が廃止されました(https://github.com/ruby/json/blob/master/CHANGES.md)。
一方 Rails 8.1.3.1 の `ActiveSupport::JSON.decode` は `::JSON.parse(json, options)` と位置引数で渡しているため、OmniAuth のコールバック(GitHub サインイン)で `ArgumentError: wrong number of arguments (given 2, expected 1)` が発生し、feature spec 10 件が失敗しました。

Rails 側は https://github.com/rails/rails/pull/58601 で修正済み(2026-08-28 に 8-1-stable へマージ)ですが、最新リリースの 8.1.3.1(2026-07-29)には含まれていません。そのため、修正を含む Rails がリリースされるまで Gemfile で `json` を `< 3` に固定しています(TODO コメント付き)。

## Test plan

- [x] `bundle exec rake` (rspec): 83 examples, 0 failures(Ruby 4.0.6, `RUBYOPT=-W:deprecated` で警告なし)
- [x] `bundle exec brakeman --quiet --no-pager --exit-on-warn --exit-on-error`: 警告 0
- [x] CI(build / brakeman ともに成功)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXrstQmuibexeM8TCEVhJq